### PR TITLE
29 singularity make file names consistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ skunk/*
 tests/*
 *.sif
 config/improve.env
+*__pycache__

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ test: $(TEST_LOGS)
 $(TEST_DIR)/%.log: $(BUILD_DIR)/%.sif
 	log=`basename $@` ;\
 	    singularity exec --bind $(TEST_DIR):/candle_data_dir $< sh -c "echo \`date\` > /candle_data_dir/$${log}" ;\
-	    sh test/test-container $? '' $(TEST_DIR) 2> $(TEST_DIR)/$${log}.error 1> $(TEST_DIR)/$${log}.tests
+	    sh test/test_container.sh $? '' $(TEST_DIR) 2> $(TEST_DIR)/$${log}.error 1> $(TEST_DIR)/$${log}.tests
 	
 
 deploy: $(SIF_FILES)

--- a/test/README.md
+++ b/test/README.md
@@ -1,7 +1,7 @@
 # Testing scripts
 
-- test-model
-- test-container
+- test_model.sh
+- test_container.sh
 - test_candle.py
 
 ## Test model interface scripts


### PR DESCRIPTION
Consistent naming for test scripts.
Required changes to test/README.md and Makefile. 

closes #29 