### PR TITLE
Uno updated . Standardized for IMPROVE functions and datasets

### DIFF
--- a/definitions/Uno.def
+++ b/definitions/Uno.def
@@ -1,50 +1,58 @@
 Bootstrap: docker
-From: python:3.7
+From: tensorflow/tensorflow:2.11.0-gpu
 
 %labels
-        MAINTAINER      woz@anl.gov / weaverr@anl.gov
-        VERSION v0.0.2
+	MAINTAINERS	woz@anl.gov and weaverr@anl.gov
+	VERSION	v0.0.2
 
 %setup
-        mkdir -p $SINGULARITY_ROOTFS/IMPROVE
-        cp src/Singularity_gpu_fix.sh $SINGULARITY_ROOTFS/IMPROVE/
+	mkdir -p $SINGULARITY_ROOTFS/IMPROVE
+	cp src/Singularity_gpu_fix.sh $SINGULARITY_ROOTFS/IMPROVE/
 
 %environment
-        # Available at runtime not build time
-        MODEL="Uno"
-        PATH=$PATH:$SINGULARITY_ROOTFS/IMPROVE/${MODEL}
-        WORK_DIR=$SINGULARITY_ROOTFS/IMPROVE/
-        CANDLE_DATA_DIR=/candle_data_dir
-        export PYTHONPATH=/opt/IMPROVE/:$PYTHONPATH
+	# Available at runtime not build time
+	export MODEL="Uno"
+	
+	# WORK_DIR=$SINGULARITY_ROOTFS/IMPROVE/
+	
+    	export CANDLE_DATA_DIR=/candle_data_dir
+	export IMPROVE_DATA_DIR=/candle_data_dir
+	export PYTHONPATH=/usr/local/IMPROVE:$PYTHONPATH
+	export IMPROVE_MODEL_DIR=/usr/local/Benchmarks/Pilot1/Uno_IMPROVE/
 
 %post
     # Install prerequisites and update image
     # See this thread for more information about apt-keys for NVIDIA:
     # https://forums.developer.nvidia.com/t/invalid-public-key-for-cuda-apt-repository/212901/18
-    # apt-get install wget
+    apt-get install wget
     # apt-key del 7fa2af80
     # rm -v /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list
     # wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
     # dpkg -i cuda-keyring_1.0-1_all.deb
     apt-get update
     apt-get install -y git ed
-    python -m pip install tensorflow==2.10.0-gpu scikit-learn==1.0.2 pyarrow==12.0.1 joblib==1.3.2
+    python -m pip install numba scikit-learn
 
     mkdir -p $SINGULARITY_ROOTFS/IMPROVE /candle_data_dir
     cd $SINGULARITY_ROOTFS/IMPROVE
     chmod a+x Singularity_gpu_fix.sh
     ./Singularity_gpu_fix.sh
     cd /usr/local
-    git clone -b develop https://github.com/JDACS4C-IMPROVE/IMPROVE.git /opt/IMPROVE
-    git clone -b develop https://github.com/ECP-CANDLE/candle_lib.git
+    git clone https://github.com/ECP-CANDLE/candle_lib.git
     cd candle_lib
+    git checkout develop
     python -m pip install .
     cd -
+    git clone --branch 12.2023.alpha https://github.com/JDACS4C-IMPROVE/IMPROVE.git
     git clone https://github.com/JDACS4C-IMPROVE/Benchmarks.git
     cd Benchmarks
-    git checkout preprocess_improve
-    cp /usr/local/Benchmarks/Pilot1/Uno_IMPROVE/* /usr/local/bin
-    
+    git checkout preprocess_improve 
+    cp /usr/local/Benchmarks/Pilot1/Uno_IMPROVE/preprocess.sh /usr/local/bin
+    cp /usr/local/Benchmarks/Pilot1/Uno_IMPROVE/train.sh /usr/local/bin
+    # cp /usr/local/Benchmarks/Pilot1/Uno_IMPROVE/infer.sh /usr/local/bin
+    chmod a+x /usr/local/bin/*
+
 
 # Local Variables:
 # mode: sh;
+# End:

--- a/definitions/Uno.def
+++ b/definitions/Uno.def
@@ -1,58 +1,50 @@
 Bootstrap: docker
-From: tensorflow/tensorflow:2.11.0-gpu
+From: python:3.7
 
 %labels
-	MAINTAINERS	woz@anl.gov and weaverr@anl.gov
-	VERSION	v0.0.2
+        MAINTAINER      woz@anl.gov / weaverr@anl.gov
+        VERSION v0.0.2
 
 %setup
-	mkdir -p $SINGULARITY_ROOTFS/IMPROVE
-	cp src/Singularity_gpu_fix.sh $SINGULARITY_ROOTFS/IMPROVE/
+        mkdir -p $SINGULARITY_ROOTFS/IMPROVE
+        cp src/Singularity_gpu_fix.sh $SINGULARITY_ROOTFS/IMPROVE/
 
 %environment
-	# Available at runtime not build time
-	export MODEL="Uno"
-	
-	# WORK_DIR=$SINGULARITY_ROOTFS/IMPROVE/
-	
-    	export CANDLE_DATA_DIR=/candle_data_dir
-	export IMPROVE_DATA_DIR=/candle_data_dir
-	export PYTHONPATH=/usr/local/IMPROVE:$PYTHONPATH
-	export IMPROVE_MODEL_DIR=/usr/local/Benchmarks/Pilot1/Uno_IMPROVE/
+        # Available at runtime not build time
+        MODEL="Uno"
+        PATH=$PATH:$SINGULARITY_ROOTFS/IMPROVE/${MODEL}
+        WORK_DIR=$SINGULARITY_ROOTFS/IMPROVE/
+        CANDLE_DATA_DIR=/candle_data_dir
+        export PYTHONPATH=/opt/IMPROVE/:$PYTHONPATH
 
 %post
     # Install prerequisites and update image
     # See this thread for more information about apt-keys for NVIDIA:
     # https://forums.developer.nvidia.com/t/invalid-public-key-for-cuda-apt-repository/212901/18
-    apt-get install wget
+    # apt-get install wget
     # apt-key del 7fa2af80
     # rm -v /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list
     # wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
     # dpkg -i cuda-keyring_1.0-1_all.deb
     apt-get update
     apt-get install -y git ed
-    python -m pip install numba scikit-learn
+    python -m pip install tensorflow==2.10.0 scikit-learn==1.0.2 pyarrow==12.0.1 joblib==1.3.2
 
     mkdir -p $SINGULARITY_ROOTFS/IMPROVE /candle_data_dir
     cd $SINGULARITY_ROOTFS/IMPROVE
     chmod a+x Singularity_gpu_fix.sh
     ./Singularity_gpu_fix.sh
     cd /usr/local
-    git clone https://github.com/ECP-CANDLE/candle_lib.git
+    git clone -b develop https://github.com/JDACS4C-IMPROVE/IMPROVE.git /opt/IMPROVE
+    git clone -b develop https://github.com/ECP-CANDLE/candle_lib.git
     cd candle_lib
-    git checkout develop
     python -m pip install .
     cd -
-    git clone --branch 12.2023.alpha https://github.com/JDACS4C-IMPROVE/IMPROVE.git
     git clone https://github.com/JDACS4C-IMPROVE/Benchmarks.git
     cd Benchmarks
-    git checkout preprocess_improve 
-    cp /usr/local/Benchmarks/Pilot1/Uno_IMPROVE/preprocess.sh /usr/local/bin
-    cp /usr/local/Benchmarks/Pilot1/Uno_IMPROVE/train.sh /usr/local/bin
-    # cp /usr/local/Benchmarks/Pilot1/Uno_IMPROVE/infer.sh /usr/local/bin
-    chmod a+x /usr/local/bin/*
-
+    git checkout preprocess_improve
+    cp /usr/local/Benchmarks/Pilot1/Uno_IMPROVE/* /usr/local/bin
+    
 
 # Local Variables:
 # mode: sh;
-# End:

--- a/definitions/Uno.def
+++ b/definitions/Uno.def
@@ -28,7 +28,7 @@ From: python:3.7
     # dpkg -i cuda-keyring_1.0-1_all.deb
     apt-get update
     apt-get install -y git ed
-    python -m pip install tensorflow==2.10.0 scikit-learn==1.0.2 pyarrow==12.0.1 joblib==1.3.2
+    python -m pip install tensorflow==2.10.0-gpu scikit-learn==1.0.2 pyarrow==12.0.1 joblib==1.3.2
 
     mkdir -p $SINGULARITY_ROOTFS/IMPROVE /candle_data_dir
     cd $SINGULARITY_ROOTFS/IMPROVE

--- a/definitions/Uno_Improve.def
+++ b/definitions/Uno_Improve.def
@@ -43,7 +43,7 @@ From: python:3.7
     git clone https://github.com/JDACS4C-IMPROVE/Benchmarks.git
     cd Benchmarks
     git checkout preprocess_improve
-    cp /usr/local/Benchmarks/Pilot1/Uno_IMPROVE/* /usr/local/bin
+    cp -r /usr/local/Benchmarks/Pilot1/Uno_IMPROVE/* /usr/local/bin
     
 
 # Local Variables:

--- a/definitions/Uno_Improve.def
+++ b/definitions/Uno_Improve.def
@@ -28,7 +28,7 @@ From: python:3.7
     # dpkg -i cuda-keyring_1.0-1_all.deb
     apt-get update
     apt-get install -y git ed
-    python -m pip install tensorflow==2.10.0-gpu scikit-learn==1.0.2 pyarrow==12.0.1 joblib==1.3.2
+    python -m pip install tensorflow-gpu==2.10.0 scikit-learn==1.0.2 pyarrow==12.0.1 joblib==1.3.2
 
     mkdir -p $SINGULARITY_ROOTFS/IMPROVE /candle_data_dir
     cd $SINGULARITY_ROOTFS/IMPROVE

--- a/definitions/Uno_Improve.def
+++ b/definitions/Uno_Improve.def
@@ -1,0 +1,50 @@
+Bootstrap: docker
+From: python:3.7
+
+%labels
+        MAINTAINER      woz@anl.gov / weaverr@anl.gov
+        VERSION v0.0.2
+
+%setup
+        mkdir -p $SINGULARITY_ROOTFS/IMPROVE
+        cp src/Singularity_gpu_fix.sh $SINGULARITY_ROOTFS/IMPROVE/
+
+%environment
+        # Available at runtime not build time
+        MODEL="Uno"
+        PATH=$PATH:$SINGULARITY_ROOTFS/IMPROVE/${MODEL}
+        WORK_DIR=$SINGULARITY_ROOTFS/IMPROVE/
+        CANDLE_DATA_DIR=/candle_data_dir
+        export PYTHONPATH=/opt/IMPROVE/:$PYTHONPATH
+
+%post
+    # Install prerequisites and update image
+    # See this thread for more information about apt-keys for NVIDIA:
+    # https://forums.developer.nvidia.com/t/invalid-public-key-for-cuda-apt-repository/212901/18
+    # apt-get install wget
+    # apt-key del 7fa2af80
+    # rm -v /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list
+    # wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
+    # dpkg -i cuda-keyring_1.0-1_all.deb
+    apt-get update
+    apt-get install -y git ed
+    python -m pip install tensorflow==2.10.0-gpu scikit-learn==1.0.2 pyarrow==12.0.1 joblib==1.3.2
+
+    mkdir -p $SINGULARITY_ROOTFS/IMPROVE /candle_data_dir
+    cd $SINGULARITY_ROOTFS/IMPROVE
+    chmod a+x Singularity_gpu_fix.sh
+    ./Singularity_gpu_fix.sh
+    cd /usr/local
+    git clone -b develop https://github.com/JDACS4C-IMPROVE/IMPROVE.git /opt/IMPROVE
+    git clone -b develop https://github.com/ECP-CANDLE/candle_lib.git
+    cd candle_lib
+    python -m pip install .
+    cd -
+    git clone https://github.com/JDACS4C-IMPROVE/Benchmarks.git
+    cd Benchmarks
+    git checkout preprocess_improve
+    cp /usr/local/Benchmarks/Pilot1/Uno_IMPROVE/* /usr/local/bin
+    
+
+# Local Variables:
+# mode: sh;


### PR DESCRIPTION
Feedback desired. I have created this def file to run with the updated Uno, standardized to use the new improve library and datasets. If trying this on lambda0, you can use:

export IMPROVE_DATA_DIR=/tmp/weaverr/Data
singularity exec /software/improve/images/uno_improve.sif train.sh 0 $IMPROVE_DATA_DIR

since I believe tmp is public to read whatever I have there.


If you want the data from scratch, this is the command:

wget --cut-dirs=8 -P ./ -nH -np -m https://web.cels.anl.gov/projects/IMPROVE_FTP/candle/public/improve/benchmarks/single_drug_drp/benchmark-data-pilot1/csa_data/